### PR TITLE
updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 dnspython
 tld
 pyrax
+monotonic
+debtcollector
+pytz
+positional
+oslo.config
+keystoneauth1
+netifaces


### PR DESCRIPTION
I needed to install the following during a recent run on a new server running Ubuntu 14.04.4 LTS to make it work:
monotonic
debtcollector
pytz
positional
oslo.config
keystoneauth1
netifaces
